### PR TITLE
Adjust search path.

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,4 +1,4 @@
 :set prompt ">>> "
-:set -iexercises:src
+:set -iexercises/HAD:src
 :m + Test.DocTest
 :l HAD

--- a/src/HAD.hs
+++ b/src/HAD.hs
@@ -72,8 +72,8 @@ checkFile fn = let
 -- 
 -- check "HAD.Y2014.M02.D24"
 checkModule :: String -> IO ()
-checkModule = doctest . ("-iexercises":) . return
+checkModule = doctest . ("-iexercises/HAD":) . return
 
 -- helper that build modules list
 modules :: DateCommand [String]
-modules (y,m,d) = "HAD": zipWith printf ["Y%4d", "M%02d", "D%02d"] [y,m,d]
+modules (y,m,d) = zipWith printf ["Y%4d", "M%02d", "D%02d"] [y,m,d]


### PR DESCRIPTION
When following the instructions in the README file, the ghci complains
about a mismatch between file name and module name.
For example:
```
>>> check =<< date 2017 1 4

exercises/HAD/Y2017/M01/D04/Exercise.hs:1:8: error:
    File name does not match module name:
    Saw: ‘Y2017.M01.D04.Exercise’
    Expected: ‘HAD.Y2017.M01.D04.Exercise’
*** Exception: ExitFailure 1
```
 It expects each module to start with 'HAD' because the search path is set to 'exercises'
instead of 'excercises/HAD'. This commit fixes the issue by adjusting
the search path.